### PR TITLE
feat: divide token literals into categories

### DIFF
--- a/src/br/univali/ttoproject/compiler/parser/Token.java
+++ b/src/br/univali/ttoproject/compiler/parser/Token.java
@@ -118,65 +118,64 @@ public class Token implements java.io.Serializable {
      */
     public static CategorizedToken newToken(int ofKind, String image) {
         switch (ofKind) {
-        case ParserConstants.PROGRAM:
-        case ParserConstants.DEFINE:
-        case ParserConstants.NOT:
-        case ParserConstants.VARIABLE:
-        case ParserConstants.IS:
-        case ParserConstants.NATURAL:
-        case ParserConstants.REAL:
-        case ParserConstants.CHAR:
-        case ParserConstants.BOOLEAN:
-        case ParserConstants.EXECUTE:
-        case ParserConstants.SET:
-        case ParserConstants.TO:
-        case ParserConstants.GET:
-        case ParserConstants.PUT:
-        case ParserConstants.VERIFY:
-        case ParserConstants.TRUE:
-        case ParserConstants.FALSE:
-        case ParserConstants.LOOP:
-        case ParserConstants.WHILE:
-        case ParserConstants.DO:
-            return new CategorizedToken(TokenCategory.Keyword, ofKind, image);
-        case ParserConstants.PLUS:
-        case ParserConstants.MINUS:
-        case ParserConstants.POWER:
-        case ParserConstants.MULTIPLICATION:
-        case ParserConstants.DIVISION:
-        case ParserConstants.INTEGER_DIVISION:
-        case ParserConstants.REST:
-        case ParserConstants.EQUAL:
-        case ParserConstants.DIFFERENT:
-        case ParserConstants.SMALLER:
-        case ParserConstants.LARGER:
-        case ParserConstants.SMALLER_EQUAL:
-        case ParserConstants.LARGER_EQUAL:
-        case ParserConstants.AND:
-        case ParserConstants.OR:
-        case ParserConstants.NOT_SYMBOL:
-            return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
-        case ParserConstants.IDENTIFIER:
-        case ParserConstants.LETTER:
-            return new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, image);
-        case ParserConstants.UNSIGNED:
-        case ParserConstants.SIGNED:
-            return new CategorizedToken(TokenCategory.IntegerConstant, ofKind, image);
-        case ParserConstants.REAL_UNSIGNED:
-        case ParserConstants.REAL_SIGNED:
-            return new CategorizedToken(TokenCategory.RealConstant, ofKind, image);
-        case ParserConstants.STRING:
-            return new CategorizedToken(TokenCategory.LiteralConstant, ofKind, image);
-        case ParserConstants.EOF:
-        case ParserConstants.LBRACE:
-        case ParserConstants.RBRACE:
-        case ParserConstants.PARENTHESESL:
-        case ParserConstants.PARANTHESESR:
-        case ParserConstants.DOT:
-        case ParserConstants.COMMA:
-            return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
-        default:
-            return new CategorizedToken(TokenCategory.Unknown, ofKind, image);
+            case ParserConstants.PROGRAM:
+            case ParserConstants.DEFINE:
+            case ParserConstants.NOT:
+            case ParserConstants.VARIABLE:
+            case ParserConstants.IS:
+            case ParserConstants.NATURAL:
+            case ParserConstants.REAL:
+            case ParserConstants.CHAR:
+            case ParserConstants.BOOLEAN:
+            case ParserConstants.EXECUTE:
+            case ParserConstants.SET:
+            case ParserConstants.TO:
+            case ParserConstants.GET:
+            case ParserConstants.PUT:
+            case ParserConstants.VERIFY:
+            case ParserConstants.TRUE:
+            case ParserConstants.FALSE:
+            case ParserConstants.LOOP:
+            case ParserConstants.WHILE:
+            case ParserConstants.DO:
+                return new CategorizedToken(TokenCategory.Keyword, ofKind, image);
+            case ParserConstants.IDENTIFIER:
+            case ParserConstants.LETTER:
+                return new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, image);
+            case ParserConstants.UNSIGNED:
+            case ParserConstants.SIGNED:
+                return new CategorizedToken(TokenCategory.IntegerConstant, ofKind, image);
+            case ParserConstants.REAL_UNSIGNED:
+            case ParserConstants.REAL_SIGNED:
+                return new CategorizedToken(TokenCategory.RealConstant, ofKind, image);
+            case ParserConstants.STRING:
+                return new CategorizedToken(TokenCategory.LiteralConstant, ofKind, image);
+            case ParserConstants.EOF:
+            case ParserConstants.LBRACE:
+            case ParserConstants.RBRACE:
+            case ParserConstants.PARENTHESESL:
+            case ParserConstants.PARANTHESESR:
+            case ParserConstants.DOT:
+            case ParserConstants.COMMA:
+            case ParserConstants.PLUS:
+            case ParserConstants.MINUS:
+            case ParserConstants.POWER:
+            case ParserConstants.MULTIPLICATION:
+            case ParserConstants.DIVISION:
+            case ParserConstants.INTEGER_DIVISION:
+            case ParserConstants.REST:
+            case ParserConstants.EQUAL:
+            case ParserConstants.DIFFERENT:
+            case ParserConstants.SMALLER:
+            case ParserConstants.LARGER:
+            case ParserConstants.SMALLER_EQUAL:
+            case ParserConstants.LARGER_EQUAL:
+            case ParserConstants.AND:
+            case ParserConstants.OR:
+            case ParserConstants.NOT_SYMBOL:
+                return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
+            default:
+                return new CategorizedToken(TokenCategory.Unknown, ofKind, image);
         }
     }
 

--- a/src/br/univali/ttoproject/compiler/parser/Token.java
+++ b/src/br/univali/ttoproject/compiler/parser/Token.java
@@ -9,16 +9,15 @@ package br.univali.ttoproject.compiler.parser;
 public class Token implements java.io.Serializable {
 
     /**
-     * The version identifier for this Serializable class.
-     * Increment only if the <i>serialized</i> form of the
-     * class changes.
+     * The version identifier for this Serializable class. Increment only if the
+     * <i>serialized</i> form of the class changes.
      */
     private static final long serialVersionUID = 1L;
 
     /**
-     * An integer that describes the kind of this token.  This numbering
-     * system is determined by JavaCCParser, and a table of these numbers is
-     * stored in the file ...Constants.java.
+     * An integer that describes the kind of this token. This numbering system is
+     * determined by JavaCCParser, and a table of these numbers is stored in the
+     * file ...Constants.java.
      */
     public int kind;
 
@@ -45,36 +44,33 @@ public class Token implements java.io.Serializable {
     public String image;
 
     /**
-     * A reference to the next regular (non-special) token from the input
-     * stream.  If this is the last token from the input stream, or if the
-     * token manager has not read tokens beyond this one, this field is
-     * set to null.  This is true only if this token is also a regular
-     * token.  Otherwise, see below for a description of the contents of
-     * this field.
+     * A reference to the next regular (non-special) token from the input stream. If
+     * this is the last token from the input stream, or if the token manager has not
+     * read tokens beyond this one, this field is set to null. This is true only if
+     * this token is also a regular token. Otherwise, see below for a description of
+     * the contents of this field.
      */
     public Token next;
 
     /**
-     * This field is used to access special tokens that occur prior to this
-     * token, but after the immediately preceding regular (non-special) token.
-     * If there are no such special tokens, this field is set to null.
-     * When there are more than one such special token, this field refers
-     * to the last of these special tokens, which in turn refers to the next
-     * previous special token through its specialToken field, and so on
-     * until the first special token (whose specialToken field is null).
-     * The next fields of special tokens refer to other special tokens that
-     * immediately follow it (without an intervening regular token).  If there
-     * is no such token, this field is null.
+     * This field is used to access special tokens that occur prior to this token,
+     * but after the immediately preceding regular (non-special) token. If there are
+     * no such special tokens, this field is set to null. When there are more than
+     * one such special token, this field refers to the last of these special
+     * tokens, which in turn refers to the next previous special token through its
+     * specialToken field, and so on until the first special token (whose
+     * specialToken field is null). The next fields of special tokens refer to other
+     * special tokens that immediately follow it (without an intervening regular
+     * token). If there is no such token, this field is null.
      */
     public Token specialToken;
 
     /**
-     * An optional attribute value of the Token.
-     * Tokens which are not used as syntactic sugar will often contain
-     * meaningful values that will be used later on by the compiler or
-     * interpreter. This attribute value is often different from the image.
-     * Any subclass of Token that actually wants to return a non-null value can
-     * override this method as appropriate.
+     * An optional attribute value of the Token. Tokens which are not used as
+     * syntactic sugar will often contain meaningful values that will be used later
+     * on by the compiler or interpreter. This attribute value is often different
+     * from the image. Any subclass of Token that actually wants to return a
+     * non-null value can override this method as appropriate.
      */
     public Object getValue() {
         return null;
@@ -109,76 +105,78 @@ public class Token implements java.io.Serializable {
     }
 
     /**
-     * Returns a new Token object, by default. However, if you want, you
-     * can create and return subclass objects based on the value of ofKind.
-     * Simply add the cases to the switch for all those special cases.
-     * For example, if you have a subclass of Token called IDToken that
-     * you want to create if ofKind is ID, simply add something like :
+     * Returns a new Token object, by default. However, if you want, you can create
+     * and return subclass objects based on the value of ofKind. Simply add the
+     * cases to the switch for all those special cases. For example, if you have a
+     * subclass of Token called IDToken that you want to create if ofKind is ID,
+     * simply add something like :
      * <p>
      * case MyParserConstants.ID : return new IDToken(ofKind, image);
      * <p>
-     * to the following switch statement. Then you can cast matchedToken
-     * variable to the appropriate type and use sit in your lexical actions.
+     * to the following switch statement. Then you can cast matchedToken variable to
+     * the appropriate type and use sit in your lexical actions.
      */
     public static CategorizedToken newToken(int ofKind, String image) {
         switch (ofKind) {
-            case ParserConstants.PROGRAM:
-            case ParserConstants.DEFINE:
-            case ParserConstants.NOT:
-            case ParserConstants.VARIABLE:
-            case ParserConstants.IS:
-            case ParserConstants.NATURAL:
-            case ParserConstants.REAL:
-            case ParserConstants.CHAR:
-            case ParserConstants.BOOLEAN:
-            case ParserConstants.EXECUTE:
-            case ParserConstants.SET:
-            case ParserConstants.TO:
-            case ParserConstants.GET:
-            case ParserConstants.PUT:
-            case ParserConstants.VERIFY:
-            case ParserConstants.TRUE:
-            case ParserConstants.FALSE:
-            case ParserConstants.LOOP:
-            case ParserConstants.WHILE:
-            case ParserConstants.DO:
-                return new CategorizedToken(TokenCategory.Keyword, ofKind, image);
-            case ParserConstants.PLUS:
-            case ParserConstants.MINUS:
-            case ParserConstants.POWER:
-            case ParserConstants.MULTIPLICATION:
-            case ParserConstants.DIVISION:
-            case ParserConstants.INTEGER_DIVISION:
-            case ParserConstants.REST:
-            case ParserConstants.EQUAL:
-            case ParserConstants.DIFFERENT:
-            case ParserConstants.SMALLER:
-            case ParserConstants.LARGER:
-            case ParserConstants.SMALLER_EQUAL:
-            case ParserConstants.LARGER_EQUAL:
-            case ParserConstants.AND:
-            case ParserConstants.OR:
-            case ParserConstants.NOT_SYMBOL:
-                return new CategorizedToken(TokenCategory.Operator, ofKind, image);
-            case ParserConstants.IDENTIFIER:
-            case ParserConstants.LETTER:
-                return new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, image);
-            case ParserConstants.UNSIGNED:
-            case ParserConstants.SIGNED:
-            case ParserConstants.REAL_UNSIGNED:
-            case ParserConstants.REAL_SIGNED:
-            case ParserConstants.STRING:
-                return new CategorizedToken(TokenCategory.Literal, ofKind, image);
-            case ParserConstants.EOF:
-            case ParserConstants.LBRACE:
-            case ParserConstants.RBRACE:
-            case ParserConstants.PARENTHESESL:
-            case ParserConstants.PARANTHESESR:
-            case ParserConstants.DOT:
-            case ParserConstants.COMMA:
-                return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
-            default:
-                return new CategorizedToken(TokenCategory.Unknown, ofKind, image);
+        case ParserConstants.PROGRAM:
+        case ParserConstants.DEFINE:
+        case ParserConstants.NOT:
+        case ParserConstants.VARIABLE:
+        case ParserConstants.IS:
+        case ParserConstants.NATURAL:
+        case ParserConstants.REAL:
+        case ParserConstants.CHAR:
+        case ParserConstants.BOOLEAN:
+        case ParserConstants.EXECUTE:
+        case ParserConstants.SET:
+        case ParserConstants.TO:
+        case ParserConstants.GET:
+        case ParserConstants.PUT:
+        case ParserConstants.VERIFY:
+        case ParserConstants.TRUE:
+        case ParserConstants.FALSE:
+        case ParserConstants.LOOP:
+        case ParserConstants.WHILE:
+        case ParserConstants.DO:
+            return new CategorizedToken(TokenCategory.Keyword, ofKind, image);
+        case ParserConstants.PLUS:
+        case ParserConstants.MINUS:
+        case ParserConstants.POWER:
+        case ParserConstants.MULTIPLICATION:
+        case ParserConstants.DIVISION:
+        case ParserConstants.INTEGER_DIVISION:
+        case ParserConstants.REST:
+        case ParserConstants.EQUAL:
+        case ParserConstants.DIFFERENT:
+        case ParserConstants.SMALLER:
+        case ParserConstants.LARGER:
+        case ParserConstants.SMALLER_EQUAL:
+        case ParserConstants.LARGER_EQUAL:
+        case ParserConstants.AND:
+        case ParserConstants.OR:
+        case ParserConstants.NOT_SYMBOL:
+            return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
+        case ParserConstants.IDENTIFIER:
+        case ParserConstants.LETTER:
+            return new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, image);
+        case ParserConstants.UNSIGNED:
+        case ParserConstants.SIGNED:
+            return new CategorizedToken(TokenCategory.IntegerConstant, ofKind, image);
+        case ParserConstants.REAL_UNSIGNED:
+        case ParserConstants.REAL_SIGNED:
+            return new CategorizedToken(TokenCategory.RealConstant, ofKind, image);
+        case ParserConstants.STRING:
+            return new CategorizedToken(TokenCategory.LiteralConstant, ofKind, image);
+        case ParserConstants.EOF:
+        case ParserConstants.LBRACE:
+        case ParserConstants.RBRACE:
+        case ParserConstants.PARENTHESESL:
+        case ParserConstants.PARANTHESESR:
+        case ParserConstants.DOT:
+        case ParserConstants.COMMA:
+            return new CategorizedToken(TokenCategory.SpecialSymbol, ofKind, image);
+        default:
+            return new CategorizedToken(TokenCategory.Unknown, ofKind, image);
         }
     }
 
@@ -187,4 +185,7 @@ public class Token implements java.io.Serializable {
     }
 
 }
-/* JavaCC - OriginalChecksum=013ca11c0293a101b3d80e7fd4da66b8 (do not edit this line) */
+/*
+ * JavaCC - OriginalChecksum=013ca11c0293a101b3d80e7fd4da66b8 (do not edit this
+ * line)
+ */

--- a/src/br/univali/ttoproject/compiler/parser/TokenCategory.java
+++ b/src/br/univali/ttoproject/compiler/parser/TokenCategory.java
@@ -31,29 +31,39 @@ public enum TokenCategory {
             return String.format("Identifier(%d)", id());
         }
     },
-    Literal {
+    LiteralConstant {
         public int id() {
             return 3;
         }
 
         @Override
         public String toString() {
-            return String.format("Literal(%d)", id());
+            return String.format("LiteralConstant(%d)", id());
         }
     },
-    Operator {
+    IntegerConstant {
         public int id() {
             return 4;
         }
 
         @Override
         public String toString() {
-            return String.format("Operator(%d)", id());
+            return String.format("IntegerConstant(%d)", id());
+        }
+    },
+    RealConstant {
+        public int id() {
+            return 5;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("RealConstant(%d)", id());
         }
     },
     Unknown {
         public int id() {
-            return 5;
+            return 6;
         }
 
         @Override

--- a/src/br/univali/ttoproject/ide/App.java
+++ b/src/br/univali/ttoproject/ide/App.java
@@ -11,7 +11,6 @@ import javax.swing.text.Utilities;
 import java.awt.*;
 import java.awt.event.*;
 import java.io.*;
-import java.util.Set;
 import java.util.function.Supplier;
 
 public class App extends JFrame {

--- a/src/br/univali/ttoproject/ide/App.java
+++ b/src/br/univali/ttoproject/ide/App.java
@@ -37,9 +37,9 @@ public class App extends JFrame {
         try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
         } catch (ClassNotFoundException |
-                 InstantiationException |
-                 IllegalAccessException |
-                 UnsupportedLookAndFeelException ex) {
+                InstantiationException |
+                IllegalAccessException |
+                UnsupportedLookAndFeelException ex) {
             java.util.logging.Logger.getLogger(App.class.getName()).log(java.util.logging.Level.SEVERE, null, ex);
         }
 
@@ -281,13 +281,13 @@ public class App extends JFrame {
         }
     }
 
-    private void cInit(){
+    private void cInit() {
         allowConsoleInput = true;
         allowedCaretPosition = taConsole.getCaretPosition();
         initialCaretPosition = allowedCaretPosition;
     }
 
-    private void cStop(){
+    private void cStop() {
         allowConsoleInput = false;
     }
 
@@ -305,19 +305,19 @@ public class App extends JFrame {
         var keyChar = e.getKeyChar();
         var curCaretPosition = taConsole.getCaretPosition();
 
-        if (keyChar == '\b'){
-            if (curCaretPosition > initialCaretPosition){
+        if (keyChar == '\b') {
+            if (curCaretPosition > initialCaretPosition) {
                 allowedCaretPosition--;
             } else {
                 e.consume();
             }
             return;
         }
-        if (keyChar == '\n'){
+        if (keyChar == '\n') {
             cStop();
             return;
         }
-        if (keyChar == '\t'){
+        if (keyChar == '\t') {
             e.consume();
             return;
         }

--- a/src/test/br/univali/ttoproject/compiler/CompilerTest.java
+++ b/src/test/br/univali/ttoproject/compiler/CompilerTest.java
@@ -12,313 +12,310 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestCase {
-    public final String input;
-    public final List<Token> expected;
+        public final String input;
+        public final List<Token> expected;
 
-    public TestCase(String input, List<Token> expected) {
-        this.input = input;
-        this.expected = expected;
-    }
+        public TestCase(String input, List<Token> expected) {
+                this.input = input;
+                this.expected = expected;
+        }
 }
 
 public class CompilerTest {
-    @Test
-    public void ignoresComments() {
-        List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
+        @Test
+        public void ignoresComments() {
+                List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
 
-        for (String input : testCases) {
-            var compiler = new Compiler();
+                for (String input : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(input)));
+                        compiler.setParser(new Parser(new StringReader(input)));
 
-            try {
-                var actual = compiler.tokenize();
+                        try {
+                                var actual = compiler.tokenize();
 
-                assertTrue(actual.isEmpty());
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                                assertTrue(actual.isEmpty());
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
-    @Test
-    public void isCaseInsensitiveWhenLexingKeywords() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-                new TestCase("Define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
-                new TestCase("DeFiNe",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
-                new TestCase("DEFINE", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                        ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
+        @Test
+        public void isCaseInsensitiveWhenLexingKeywords() {
+                List<TestCase> testCases = Arrays.asList(
+                                new TestCase("define",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                                new TestCase("Define",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
+                                new TestCase("DeFiNe",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
+                                new TestCase("DEFINE", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            try {
-                var actual = compiler.tokenize();
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                        try {
+                                var actual = compiler.tokenize();
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
-    @Test
-    public void categorizesKeywordTokens() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("program",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
-                new TestCase("define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-                new TestCase("not",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.NOT, "not", 1, 1, 1, 3))),
-                new TestCase("variable",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
-                new TestCase("is",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.IS, "is", 1, 1, 1, 2))),
-                new TestCase("natural",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
-                new TestCase("real",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.REAL, "real", 1, 1, 1, 4))),
-                new TestCase("char",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.CHAR, "char", 1, 1, 1, 4))),
-                new TestCase("boolean",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
-                new TestCase("execute",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
-                new TestCase("set",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.SET, "set", 1, 1, 1, 3))),
-                new TestCase("to",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.TO, "to", 1, 1, 1, 2))),
-                new TestCase("get",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.GET, "get", 1, 1, 1, 3))),
-                new TestCase("put",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.PUT, "put", 1, 1, 1, 3))),
-                new TestCase("verify",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
-                new TestCase("true",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.TRUE, "true", 1, 1, 1, 4))),
-                new TestCase("false",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.FALSE, "false", 1, 1, 1, 5))),
-                new TestCase("loop",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
-                new TestCase("while",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                ParserConstants.WHILE, "while", 1, 1, 1, 5))),
-                new TestCase("do", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                        ParserConstants.DO, "do", 1, 1, 1, 2))));
+        @Test
+        public void categorizesKeywordTokens() {
+                List<TestCase> testCases = Arrays.asList(
+                                new TestCase("program",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
+                                new TestCase("define",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                                new TestCase("not",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.NOT, "not", 1, 1, 1, 3))),
+                                new TestCase("variable",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
+                                new TestCase("is",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.IS, "is", 1, 1, 1, 2))),
+                                new TestCase("natural",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
+                                new TestCase("real",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.REAL, "real", 1, 1, 1, 4))),
+                                new TestCase("char",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.CHAR, "char", 1, 1, 1, 4))),
+                                new TestCase("boolean",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
+                                new TestCase("execute",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
+                                new TestCase("set",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.SET, "set", 1, 1, 1, 3))),
+                                new TestCase("to",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.TO, "to", 1, 1, 1, 2))),
+                                new TestCase("get",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.GET, "get", 1, 1, 1, 3))),
+                                new TestCase("put",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.PUT, "put", 1, 1, 1, 3))),
+                                new TestCase("verify",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
+                                new TestCase("true",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.TRUE, "true", 1, 1, 1, 4))),
+                                new TestCase("false",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.FALSE, "false", 1, 1, 1, 5))),
+                                new TestCase("loop",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
+                                new TestCase("while",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                                ParserConstants.WHILE, "while", 1, 1, 1, 5))),
+                                new TestCase("do", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                                ParserConstants.DO, "do", 1, 1, 1, 2))));
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            try {
-                var actual = compiler.tokenize();
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                        try {
+                                var actual = compiler.tokenize();
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
+        @Test
+        public void categorizesIdentifierTokens() {
+                List<TestCase> testCases = Arrays.asList(
+                                new TestCase("x",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                                                                ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
+                                new TestCase("xyz",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                                                                ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
+                                new TestCase("xyz123", Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                                                ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
 
-    @Test
-    public void categorizesIdentifierTokens() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("x",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                                ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
-                new TestCase("xyz",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                                ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
-                new TestCase("xyz123", Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                        ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
-
-            try {
-                var actual = compiler.tokenize();
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                        try {
+                                var actual = compiler.tokenize();
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
-    @Test
-    public void categorizesLiterals() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("123",
-                        Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
-                                ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
-                new TestCase("-123",
-                        Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
-                                ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
-                new TestCase("3.14",
-                        Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
-                                ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
-                new TestCase("-3.14",
-                        Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
-                                ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
-                new TestCase("\"hello world\"",
-                        Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
-                                ParserConstants.STRING, "\"hello world\"", 1, 1, 1,
-                                13))));
+        @Test
+        public void categorizesLiterals() {
+                List<TestCase> testCases = Arrays.asList(
+                                new TestCase("123",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
+                                                                ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
+                                new TestCase("-123",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
+                                                                ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
+                                new TestCase("3.14",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
+                                                                ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
+                                new TestCase("-3.14",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
+                                                                ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
+                                new TestCase("\"hello world\"",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
+                                                                ParserConstants.STRING, "\"hello world\"", 1, 1, 1,
+                                                                13))));
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            try {
-                var actual = compiler.tokenize();
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                        try {
+                                var actual = compiler.tokenize();
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
-    @Test
-    public void categorizesSpecialSymbols() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("{",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
-                new TestCase("}",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
-                new TestCase("(",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
-                new TestCase(")",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
-                new TestCase(".",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.DOT, ".", 1, 1, 1, 1))),
-                new TestCase(",", Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                        ParserConstants.COMMA, ",", 1, 1, 1, 1))),
-                new TestCase("+",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.PLUS, "+", 1, 1, 1, 1))),
-                new TestCase("-",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.MINUS, "-", 1, 1, 1, 1))),
-                new TestCase("**",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.POWER, "**", 1, 1, 1, 2))),
-                new TestCase("*",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.MULTIPLICATION, "*", 1, 1, 1, 1))),
-                new TestCase("/",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
-                new TestCase("%",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.INTEGER_DIVISION, "%", 1, 1, 1, 1))),
-                new TestCase("%%",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.REST, "%%", 1, 1, 1, 2))),
-                new TestCase("==",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
-                new TestCase("!=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
-                new TestCase("<",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
-                new TestCase(">",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.LARGER, ">", 1, 1, 1, 1))),
-                new TestCase("<=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.SMALLER_EQUAL, "<=", 1, 1, 1, 2))),
-                new TestCase(">=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
-                new TestCase("&",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.AND, "&", 1, 1, 1, 1))),
-                new TestCase("|",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.OR, "|", 1, 1, 1, 1))),
-                new TestCase("!",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1)))
-          );
+        @Test
+        public void categorizesSpecialSymbols() {
+                List<TestCase> testCases = Arrays.asList(
+                                new TestCase("{",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
+                                new TestCase("}",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
+                                new TestCase("(",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
+                                new TestCase(")",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
+                                new TestCase(".",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.DOT, ".", 1, 1, 1, 1))),
+                                new TestCase(",",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.COMMA, ",", 1, 1, 1, 1))),
+                                new TestCase("+",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.PLUS, "+", 1, 1, 1, 1))),
+                                new TestCase("-",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.MINUS, "-", 1, 1, 1, 1))),
+                                new TestCase("**",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.POWER, "**", 1, 1, 1, 2))),
+                                new TestCase("*",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.MULTIPLICATION, "*", 1, 1, 1, 1))),
+                                new TestCase("/",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
+                                new TestCase("%",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.INTEGER_DIVISION, "%", 1, 1, 1, 1))),
+                                new TestCase("%%",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.REST, "%%", 1, 1, 1, 2))),
+                                new TestCase("==",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
+                                new TestCase("!=",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
+                                new TestCase("<",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
+                                new TestCase(">",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.LARGER, ">", 1, 1, 1, 1))),
+                                new TestCase("<=",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.SMALLER_EQUAL, "<=", 1, 1, 1, 2))),
+                                new TestCase(">=",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
+                                new TestCase("&",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.AND, "&", 1, 1, 1, 1))),
+                                new TestCase("|",
+                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                                ParserConstants.OR, "|", 1, 1, 1, 1))),
+                                new TestCase("!", Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                                ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))));
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            try {
-                var actual = compiler.tokenize();
-                System.out.println(actual);
-                System.out.println(testCase.expected);
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                        try {
+                                var actual = compiler.tokenize();
+
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 
-    @Test
-    public void categorizesUnknownTokens() {
-        List<TestCase> testCases = Arrays
-                .asList(new TestCase("?", Arrays.asList(new CategorizedToken(TokenCategory.Unknown,
-                        ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
+        @Test
+        public void categorizesUnknownTokens() {
+                List<TestCase> testCases = Arrays
+                                .asList(new TestCase("?", Arrays.asList(new CategorizedToken(TokenCategory.Unknown,
+                                                ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
 
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
+                for (TestCase testCase : testCases) {
+                        var compiler = new Compiler();
 
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
+                        compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-            try {
-                var actual = compiler.tokenize();
+                        try {
+                                var actual = compiler.tokenize();
 
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
+                                assertEquals(testCase.expected, actual);
+                        } catch (Exception e) {
+                                System.out.println(e);
+                                assertTrue(false);
+                        }
+                }
         }
-    }
 }

--- a/src/test/br/univali/ttoproject/compiler/CompilerTest.java
+++ b/src/test/br/univali/ttoproject/compiler/CompilerTest.java
@@ -12,310 +12,290 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestCase {
-        public final String input;
-        public final List<Token> expected;
+	public final String input;
+	public final List<Token> expected;
 
-        public TestCase(String input, List<Token> expected) {
-                this.input = input;
-                this.expected = expected;
-        }
+	public TestCase(String input, List<Token> expected) {
+		this.input = input;
+		this.expected = expected;
+	}
 }
 
 public class CompilerTest {
-        @Test
-        public void ignoresComments() {
-                List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
+	@Test
+	public void ignoresComments() {
+		List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
 
-                for (String input : testCases) {
-                        var compiler = new Compiler();
+		for (String input : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(input)));
+			compiler.setParser(new Parser(new StringReader(input)));
 
-                        try {
-                                var actual = compiler.tokenize();
+			try {
+				var actual = compiler.tokenize();
 
-                                assertTrue(actual.isEmpty());
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+				assertTrue(actual.isEmpty());
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void isCaseInsensitiveWhenLexingKeywords() {
-                List<TestCase> testCases = Arrays.asList(
-                                new TestCase("define",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-                                new TestCase("Define",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
-                                new TestCase("DeFiNe",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
-                                new TestCase("DEFINE", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
+	@Test
+	public void isCaseInsensitiveWhenLexingKeywords() {
+		List<TestCase> testCases = Arrays.asList(
+				new TestCase("define",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+				new TestCase("Define",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
+				new TestCase("DeFiNe",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
+				new TestCase("DEFINE",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+			try {
+				var actual = compiler.tokenize();
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void categorizesKeywordTokens() {
-                List<TestCase> testCases = Arrays.asList(
-                                new TestCase("program",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
-                                new TestCase("define",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-                                new TestCase("not",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.NOT, "not", 1, 1, 1, 3))),
-                                new TestCase("variable",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
-                                new TestCase("is",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.IS, "is", 1, 1, 1, 2))),
-                                new TestCase("natural",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
-                                new TestCase("real",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.REAL, "real", 1, 1, 1, 4))),
-                                new TestCase("char",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.CHAR, "char", 1, 1, 1, 4))),
-                                new TestCase("boolean",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
-                                new TestCase("execute",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
-                                new TestCase("set",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.SET, "set", 1, 1, 1, 3))),
-                                new TestCase("to",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.TO, "to", 1, 1, 1, 2))),
-                                new TestCase("get",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.GET, "get", 1, 1, 1, 3))),
-                                new TestCase("put",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.PUT, "put", 1, 1, 1, 3))),
-                                new TestCase("verify",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
-                                new TestCase("true",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.TRUE, "true", 1, 1, 1, 4))),
-                                new TestCase("false",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.FALSE, "false", 1, 1, 1, 5))),
-                                new TestCase("loop",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
-                                new TestCase("while",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                                ParserConstants.WHILE, "while", 1, 1, 1, 5))),
-                                new TestCase("do", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
-                                                ParserConstants.DO, "do", 1, 1, 1, 2))));
+	@Test
+	public void categorizesKeywordTokens() {
+		List<TestCase> testCases = Arrays.asList(
+				new TestCase("program",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
+				new TestCase("define",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+				new TestCase("not",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NOT, "not", 1, 1, 1, 3))),
+				new TestCase("variable",
+						Arrays
+								.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
+				new TestCase("is",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.IS, "is", 1, 1, 1, 2))),
+				new TestCase("natural",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
+				new TestCase("real",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.REAL, "real", 1, 1, 1, 4))),
+				new TestCase("char",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.CHAR, "char", 1, 1, 1, 4))),
+				new TestCase("boolean",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
+				new TestCase("execute",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
+				new TestCase("set",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.SET, "set", 1, 1, 1, 3))),
+				new TestCase("to",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TO, "to", 1, 1, 1, 2))),
+				new TestCase("get",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.GET, "get", 1, 1, 1, 3))),
+				new TestCase("put",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PUT, "put", 1, 1, 1, 3))),
+				new TestCase("verify",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
+				new TestCase("true",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TRUE, "true", 1, 1, 1, 4))),
+				new TestCase("false",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.FALSE, "false", 1, 1, 1, 5))),
+				new TestCase("loop",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
+				new TestCase("while",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.WHILE, "while", 1, 1, 1, 5))),
+				new TestCase("do",
+						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DO, "do", 1, 1, 1, 2))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+			try {
+				var actual = compiler.tokenize();
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void categorizesIdentifierTokens() {
-                List<TestCase> testCases = Arrays.asList(
-                                new TestCase("x",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                                                                ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
-                                new TestCase("xyz",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                                                                ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
-                                new TestCase("xyz123", Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
-                                                ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
+	@Test
+	public void categorizesIdentifierTokens() {
+		List<TestCase> testCases = Arrays
+				.asList(
+						new TestCase("x",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
+						new TestCase("xyz",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
+						new TestCase("xyz123", Arrays.asList(
+								new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+			try {
+				var actual = compiler.tokenize();
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void categorizesLiterals() {
-                List<TestCase> testCases = Arrays.asList(
-                                new TestCase("123",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
-                                                                ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
-                                new TestCase("-123",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
-                                                                ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
-                                new TestCase("3.14",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
-                                                                ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
-                                new TestCase("-3.14",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
-                                                                ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
-                                new TestCase("\"hello world\"",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
-                                                                ParserConstants.STRING, "\"hello world\"", 1, 1, 1,
-                                                                13))));
+	@Test
+	public void categorizesLiterals() {
+		List<TestCase> testCases = Arrays.asList(
+				new TestCase("123",
+						Arrays.asList(
+								new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
+				new TestCase("-123",
+						Arrays.asList(
+								new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
+				new TestCase("3.14",
+						Arrays.asList(
+								new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
+				new TestCase("-3.14",
+						Arrays.asList(
+								new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
+				new TestCase("\"hello world\"", Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
+						ParserConstants.STRING, "\"hello world\"", 1, 1, 1, 13))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+			try {
+				var actual = compiler.tokenize();
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void categorizesSpecialSymbols() {
-                List<TestCase> testCases = Arrays.asList(
-                                new TestCase("{",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
-                                new TestCase("}",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
-                                new TestCase("(",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
-                                new TestCase(")",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
-                                new TestCase(".",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.DOT, ".", 1, 1, 1, 1))),
-                                new TestCase(",",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.COMMA, ",", 1, 1, 1, 1))),
-                                new TestCase("+",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.PLUS, "+", 1, 1, 1, 1))),
-                                new TestCase("-",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.MINUS, "-", 1, 1, 1, 1))),
-                                new TestCase("**",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.POWER, "**", 1, 1, 1, 2))),
-                                new TestCase("*",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.MULTIPLICATION, "*", 1, 1, 1, 1))),
-                                new TestCase("/",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
-                                new TestCase("%",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.INTEGER_DIVISION, "%", 1, 1, 1, 1))),
-                                new TestCase("%%",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.REST, "%%", 1, 1, 1, 2))),
-                                new TestCase("==",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
-                                new TestCase("!=",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
-                                new TestCase("<",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
-                                new TestCase(">",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.LARGER, ">", 1, 1, 1, 1))),
-                                new TestCase("<=",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.SMALLER_EQUAL, "<=", 1, 1, 1, 2))),
-                                new TestCase(">=",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
-                                new TestCase("&",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.AND, "&", 1, 1, 1, 1))),
-                                new TestCase("|",
-                                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                                ParserConstants.OR, "|", 1, 1, 1, 1))),
-                                new TestCase("!", Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
-                                                ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))));
+	@Test
+	public void categorizesSpecialSymbols() {
+		List<TestCase> testCases = Arrays
+				.asList(
+						new TestCase("{",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
+						new TestCase("}",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
+						new TestCase("(",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
+						new TestCase(")",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
+						new TestCase(".",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DOT, ".", 1, 1, 1, 1))),
+						new TestCase(",",
+								Arrays
+										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.COMMA, ",", 1, 1, 1, 1))),
+						new TestCase("+",
+								Arrays
+										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PLUS, "+", 1, 1, 1, 1))),
+						new TestCase(
+								"-",
+								Arrays
+										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MINUS, "-", 1, 1, 1, 1))),
+						new TestCase(
+								"**",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.POWER, "**", 1, 1, 1, 2))),
+						new TestCase(
+								"*",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MULTIPLICATION, "*", 1,
+										1, 1, 1))),
+						new TestCase(
+								"/",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
+						new TestCase("%",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.INTEGER_DIVISION, "%",
+										1, 1, 1, 1))),
+						new TestCase("%%",
+								Arrays
+										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.REST, "%%", 1, 1, 1, 2))),
+						new TestCase("==",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
+						new TestCase("!=",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
+						new TestCase(
+								"<",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
+						new TestCase(">",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER, ">", 1, 1, 1, 1))),
+						new TestCase("<=",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER_EQUAL, "<=", 1,
+										1, 1, 2))),
+						new TestCase(">=",
+								Arrays.asList(
+										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
+						new TestCase("&",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.AND, "&", 1, 1, 1, 1))),
+						new TestCase("|",
+								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.OR, "|", 1, 1, 1, 1))),
+						new TestCase("!", Arrays.asList(
+								new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
+			try {
+				var actual = compiler.tokenize();
 
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 
-        @Test
-        public void categorizesUnknownTokens() {
-                List<TestCase> testCases = Arrays
-                                .asList(new TestCase("?", Arrays.asList(new CategorizedToken(TokenCategory.Unknown,
-                                                ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
+	@Test
+	public void categorizesUnknownTokens() {
+		List<TestCase> testCases = Arrays.asList(new TestCase("?",
+				Arrays.asList(new CategorizedToken(TokenCategory.Unknown, ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
 
-                for (TestCase testCase : testCases) {
-                        var compiler = new Compiler();
+		for (TestCase testCase : testCases) {
+			var compiler = new Compiler();
 
-                        compiler.setParser(new Parser(new StringReader(testCase.input)));
+			compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-                        try {
-                                var actual = compiler.tokenize();
+			try {
+				var actual = compiler.tokenize();
 
-                                assertEquals(testCase.expected, actual);
-                        } catch (Exception e) {
-                                System.out.println(e);
-                                assertTrue(false);
-                        }
-                }
-        }
+				assertEquals(testCase.expected, actual);
+			} catch (Exception e) {
+				System.out.println(e);
+				assertTrue(false);
+			}
+		}
+	}
 }

--- a/src/test/br/univali/ttoproject/compiler/CompilerTest.java
+++ b/src/test/br/univali/ttoproject/compiler/CompilerTest.java
@@ -12,290 +12,290 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TestCase {
-	public final String input;
-	public final List<Token> expected;
+    public final String input;
+    public final List<Token> expected;
 
-	public TestCase(String input, List<Token> expected) {
-		this.input = input;
-		this.expected = expected;
-	}
+    public TestCase(String input, List<Token> expected) {
+        this.input = input;
+        this.expected = expected;
+    }
 }
 
 public class CompilerTest {
-	@Test
-	public void ignoresComments() {
-		List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
+    @Test
+    public void ignoresComments() {
+        List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
 
-		for (String input : testCases) {
-			var compiler = new Compiler();
+        for (String input : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(input)));
+            compiler.setParser(new Parser(new StringReader(input)));
 
-			try {
-				var actual = compiler.tokenize();
+            try {
+                var actual = compiler.tokenize();
 
-				assertTrue(actual.isEmpty());
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+                assertTrue(actual.isEmpty());
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void isCaseInsensitiveWhenLexingKeywords() {
-		List<TestCase> testCases = Arrays.asList(
-				new TestCase("define",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-				new TestCase("Define",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
-				new TestCase("DeFiNe",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
-				new TestCase("DEFINE",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
+    @Test
+    public void isCaseInsensitiveWhenLexingKeywords() {
+        List<TestCase> testCases = Arrays.asList(
+                new TestCase("define",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                new TestCase("Define",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
+                new TestCase("DeFiNe",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
+                new TestCase("DEFINE",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+            try {
+                var actual = compiler.tokenize();
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void categorizesKeywordTokens() {
-		List<TestCase> testCases = Arrays.asList(
-				new TestCase("program",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
-				new TestCase("define",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
-				new TestCase("not",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NOT, "not", 1, 1, 1, 3))),
-				new TestCase("variable",
-						Arrays
-								.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
-				new TestCase("is",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.IS, "is", 1, 1, 1, 2))),
-				new TestCase("natural",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
-				new TestCase("real",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.REAL, "real", 1, 1, 1, 4))),
-				new TestCase("char",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.CHAR, "char", 1, 1, 1, 4))),
-				new TestCase("boolean",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
-				new TestCase("execute",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
-				new TestCase("set",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.SET, "set", 1, 1, 1, 3))),
-				new TestCase("to",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TO, "to", 1, 1, 1, 2))),
-				new TestCase("get",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.GET, "get", 1, 1, 1, 3))),
-				new TestCase("put",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PUT, "put", 1, 1, 1, 3))),
-				new TestCase("verify",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
-				new TestCase("true",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TRUE, "true", 1, 1, 1, 4))),
-				new TestCase("false",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.FALSE, "false", 1, 1, 1, 5))),
-				new TestCase("loop",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
-				new TestCase("while",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.WHILE, "while", 1, 1, 1, 5))),
-				new TestCase("do",
-						Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DO, "do", 1, 1, 1, 2))));
+    @Test
+    public void categorizesKeywordTokens() {
+        List<TestCase> testCases = Arrays.asList(
+                new TestCase("program",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
+                new TestCase("define",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                new TestCase("not",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NOT, "not", 1, 1, 1, 3))),
+                new TestCase("variable",
+                        Arrays
+                                .asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
+                new TestCase("is",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.IS, "is", 1, 1, 1, 2))),
+                new TestCase("natural",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
+                new TestCase("real",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.REAL, "real", 1, 1, 1, 4))),
+                new TestCase("char",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.CHAR, "char", 1, 1, 1, 4))),
+                new TestCase("boolean",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
+                new TestCase("execute",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
+                new TestCase("set",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.SET, "set", 1, 1, 1, 3))),
+                new TestCase("to",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TO, "to", 1, 1, 1, 2))),
+                new TestCase("get",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.GET, "get", 1, 1, 1, 3))),
+                new TestCase("put",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PUT, "put", 1, 1, 1, 3))),
+                new TestCase("verify",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
+                new TestCase("true",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TRUE, "true", 1, 1, 1, 4))),
+                new TestCase("false",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.FALSE, "false", 1, 1, 1, 5))),
+                new TestCase("loop",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
+                new TestCase("while",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.WHILE, "while", 1, 1, 1, 5))),
+                new TestCase("do",
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DO, "do", 1, 1, 1, 2))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+            try {
+                var actual = compiler.tokenize();
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void categorizesIdentifierTokens() {
-		List<TestCase> testCases = Arrays
-				.asList(
-						new TestCase("x",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
-						new TestCase("xyz",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
-						new TestCase("xyz123", Arrays.asList(
-								new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
+    @Test
+    public void categorizesIdentifierTokens() {
+        List<TestCase> testCases = Arrays
+                .asList(
+                        new TestCase("x",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
+                        new TestCase("xyz",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
+                        new TestCase("xyz123", Arrays.asList(
+                                new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+            try {
+                var actual = compiler.tokenize();
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void categorizesLiterals() {
-		List<TestCase> testCases = Arrays.asList(
-				new TestCase("123",
-						Arrays.asList(
-								new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
-				new TestCase("-123",
-						Arrays.asList(
-								new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
-				new TestCase("3.14",
-						Arrays.asList(
-								new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
-				new TestCase("-3.14",
-						Arrays.asList(
-								new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
-				new TestCase("\"hello world\"", Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
-						ParserConstants.STRING, "\"hello world\"", 1, 1, 1, 13))));
+    @Test
+    public void categorizesLiterals() {
+        List<TestCase> testCases = Arrays.asList(
+                new TestCase("123",
+                        Arrays.asList(
+                                new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
+                new TestCase("-123",
+                        Arrays.asList(
+                                new CategorizedToken(TokenCategory.IntegerConstant, ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
+                new TestCase("3.14",
+                        Arrays.asList(
+                                new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
+                new TestCase("-3.14",
+                        Arrays.asList(
+                                new CategorizedToken(TokenCategory.RealConstant, ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
+                new TestCase("\"hello world\"", Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
+                        ParserConstants.STRING, "\"hello world\"", 1, 1, 1, 13))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+            try {
+                var actual = compiler.tokenize();
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void categorizesSpecialSymbols() {
-		List<TestCase> testCases = Arrays
-				.asList(
-						new TestCase("{",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
-						new TestCase("}",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
-						new TestCase("(",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
-						new TestCase(")",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
-						new TestCase(".",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DOT, ".", 1, 1, 1, 1))),
-						new TestCase(",",
-								Arrays
-										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.COMMA, ",", 1, 1, 1, 1))),
-						new TestCase("+",
-								Arrays
-										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PLUS, "+", 1, 1, 1, 1))),
-						new TestCase(
-								"-",
-								Arrays
-										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MINUS, "-", 1, 1, 1, 1))),
-						new TestCase(
-								"**",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.POWER, "**", 1, 1, 1, 2))),
-						new TestCase(
-								"*",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MULTIPLICATION, "*", 1,
-										1, 1, 1))),
-						new TestCase(
-								"/",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
-						new TestCase("%",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.INTEGER_DIVISION, "%",
-										1, 1, 1, 1))),
-						new TestCase("%%",
-								Arrays
-										.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.REST, "%%", 1, 1, 1, 2))),
-						new TestCase("==",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
-						new TestCase("!=",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
-						new TestCase(
-								"<",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
-						new TestCase(">",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER, ">", 1, 1, 1, 1))),
-						new TestCase("<=",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER_EQUAL, "<=", 1,
-										1, 1, 2))),
-						new TestCase(">=",
-								Arrays.asList(
-										new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
-						new TestCase("&",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.AND, "&", 1, 1, 1, 1))),
-						new TestCase("|",
-								Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.OR, "|", 1, 1, 1, 1))),
-						new TestCase("!", Arrays.asList(
-								new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))));
+    @Test
+    public void categorizesSpecialSymbols() {
+        List<TestCase> testCases = Arrays
+                .asList(
+                        new TestCase("{",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
+                        new TestCase("}",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
+                        new TestCase("(",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
+                        new TestCase(")",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
+                        new TestCase(".",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DOT, ".", 1, 1, 1, 1))),
+                        new TestCase(",",
+                                Arrays
+                                        .asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.COMMA, ",", 1, 1, 1, 1))),
+                        new TestCase("+",
+                                Arrays
+                                        .asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PLUS, "+", 1, 1, 1, 1))),
+                        new TestCase(
+                                "-",
+                                Arrays
+                                        .asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MINUS, "-", 1, 1, 1, 1))),
+                        new TestCase(
+                                "**",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.POWER, "**", 1, 1, 1, 2))),
+                        new TestCase(
+                                "*",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.MULTIPLICATION, "*", 1,
+                                        1, 1, 1))),
+                        new TestCase(
+                                "/",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
+                        new TestCase("%",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.INTEGER_DIVISION, "%",
+                                        1, 1, 1, 1))),
+                        new TestCase("%%",
+                                Arrays
+                                        .asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.REST, "%%", 1, 1, 1, 2))),
+                        new TestCase("==",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
+                        new TestCase("!=",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
+                        new TestCase(
+                                "<",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
+                        new TestCase(">",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER, ">", 1, 1, 1, 1))),
+                        new TestCase("<=",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.SMALLER_EQUAL, "<=", 1,
+                                        1, 1, 2))),
+                        new TestCase(">=",
+                                Arrays.asList(
+                                        new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
+                        new TestCase("&",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.AND, "&", 1, 1, 1, 1))),
+                        new TestCase("|",
+                                Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.OR, "|", 1, 1, 1, 1))),
+                        new TestCase("!", Arrays.asList(
+                                new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
+            try {
+                var actual = compiler.tokenize();
 
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 
-	@Test
-	public void categorizesUnknownTokens() {
-		List<TestCase> testCases = Arrays.asList(new TestCase("?",
-				Arrays.asList(new CategorizedToken(TokenCategory.Unknown, ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
+    @Test
+    public void categorizesUnknownTokens() {
+        List<TestCase> testCases = Arrays.asList(new TestCase("?",
+                Arrays.asList(new CategorizedToken(TokenCategory.Unknown, ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
 
-		for (TestCase testCase : testCases) {
-			var compiler = new Compiler();
+        for (TestCase testCase : testCases) {
+            var compiler = new Compiler();
 
-			compiler.setParser(new Parser(new StringReader(testCase.input)));
+            compiler.setParser(new Parser(new StringReader(testCase.input)));
 
-			try {
-				var actual = compiler.tokenize();
+            try {
+                var actual = compiler.tokenize();
 
-				assertEquals(testCase.expected, actual);
-			} catch (Exception e) {
-				System.out.println(e);
-				assertTrue(false);
-			}
-		}
-	}
+                assertEquals(testCase.expected, actual);
+            } catch (Exception e) {
+                System.out.println(e);
+                assertTrue(false);
+            }
+        }
+    }
 }

--- a/src/test/br/univali/ttoproject/compiler/CompilerTest.java
+++ b/src/test/br/univali/ttoproject/compiler/CompilerTest.java
@@ -24,10 +24,7 @@ class TestCase {
 public class CompilerTest {
     @Test
     public void ignoresComments() {
-        List<String> testCases = Arrays.asList(
-                ":- x y + 1 123 -abd",
-                "/* hello world 1 + 2 */"
-        );
+        List<String> testCases = Arrays.asList(":- x y + 1 123 -abd", "/* hello world 1 + 2 */");
 
         for (String input : testCases) {
             var compiler = new Compiler();
@@ -49,14 +46,16 @@ public class CompilerTest {
     public void isCaseInsensitiveWhenLexingKeywords() {
         List<TestCase> testCases = Arrays.asList(
                 new TestCase("define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
                 new TestCase("Define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.DEFINE, "Define", 1, 1, 1, 6))),
                 new TestCase("DeFiNe",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
-                new TestCase("DEFINE",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
-
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.DEFINE, "DeFiNe", 1, 1, 1, 6))),
+                new TestCase("DEFINE", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                        ParserConstants.DEFINE, "DEFINE", 1, 1, 1, 6))));
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();
@@ -77,46 +76,64 @@ public class CompilerTest {
     public void categorizesKeywordTokens() {
         List<TestCase> testCases = Arrays.asList(
                 new TestCase("program",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.PROGRAM, "program", 1, 1, 1, 7))),
                 new TestCase("define",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.DEFINE, "define", 1, 1, 1, 6))),
                 new TestCase("not",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NOT, "not", 1, 1, 1, 3))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.NOT, "not", 1, 1, 1, 3))),
                 new TestCase("variable",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.VARIABLE, "variable", 1, 1, 1, 8))),
                 new TestCase("is",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.IS, "is", 1, 1, 1, 2))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.IS, "is", 1, 1, 1, 2))),
                 new TestCase("natural",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.NATURAL, "natural", 1, 1, 1, 7))),
                 new TestCase("real",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.REAL, "real", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.REAL, "real", 1, 1, 1, 4))),
                 new TestCase("char",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.CHAR, "char", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.CHAR, "char", 1, 1, 1, 4))),
                 new TestCase("boolean",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.BOOLEAN, "boolean", 1, 1, 1, 7))),
                 new TestCase("execute",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.EXECUTE, "execute", 1, 1, 1, 7))),
                 new TestCase("set",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.SET, "set", 1, 1, 1, 3))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.SET, "set", 1, 1, 1, 3))),
                 new TestCase("to",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TO, "to", 1, 1, 1, 2))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.TO, "to", 1, 1, 1, 2))),
                 new TestCase("get",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.GET, "get", 1, 1, 1, 3))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.GET, "get", 1, 1, 1, 3))),
                 new TestCase("put",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.PUT, "put", 1, 1, 1, 3))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.PUT, "put", 1, 1, 1, 3))),
                 new TestCase("verify",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.VERIFY, "verify", 1, 1, 1, 6))),
                 new TestCase("true",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.TRUE, "true", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.TRUE, "true", 1, 1, 1, 4))),
                 new TestCase("false",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.FALSE, "false", 1, 1, 1, 5))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.FALSE, "false", 1, 1, 1, 5))),
                 new TestCase("loop",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.LOOP, "loop", 1, 1, 1, 4))),
                 new TestCase("while",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.WHILE, "while", 1, 1, 1, 5))),
-                new TestCase("do",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword, ParserConstants.DO, "do", 1, 1, 1, 2)))
-        );
+                        Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                                ParserConstants.WHILE, "while", 1, 1, 1, 5))),
+                new TestCase("do", Arrays.asList(new CategorizedToken(TokenCategory.Keyword,
+                        ParserConstants.DO, "do", 1, 1, 1, 2))));
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();
@@ -133,70 +150,18 @@ public class CompilerTest {
         }
     }
 
-    @Test
-    public void categorizesOperatorTokens() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("+",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.PLUS, "+", 1, 1, 1, 1))),
-                new TestCase("-",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.MINUS, "-", 1, 1, 1, 1))),
-                new TestCase("**",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.POWER, "**", 1, 1, 1, 2))),
-                new TestCase("*",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.MULTIPLICATION, "*", 1, 1, 1, 1))),
-                new TestCase("/",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
-                new TestCase("%",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.INTEGER_DIVISION, "%", 1, 1, 1, 1))),
-                new TestCase("%%",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.REST, "%%", 1, 1, 1, 2))),
-                new TestCase("==",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
-                new TestCase("!=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
-                new TestCase("<",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
-                new TestCase(">",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.LARGER, ">", 1, 1, 1, 1))),
-                new TestCase("<=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.SMALLER_EQUAL, "<=", 1, 1, 1, 2))),
-                new TestCase(">=",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
-                new TestCase("&",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.AND, "&", 1, 1, 1, 1))),
-                new TestCase("|",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.OR, "|", 1, 1, 1, 1))),
-                new TestCase("!",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1))),
-                new TestCase("x",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Operator, ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))
-                ));
-
-        for (TestCase testCase : testCases) {
-            var compiler = new Compiler();
-
-            compiler.setParser(new Parser(new StringReader(testCase.input)));
-
-            try {
-                var actual = compiler.tokenize();
-                assertEquals(testCase.expected, actual);
-            } catch (Exception e) {
-                System.out.println(e);
-                assertTrue(false);
-            }
-        }
-    }
 
     @Test
     public void categorizesIdentifierTokens() {
         List<TestCase> testCases = Arrays.asList(
                 new TestCase("x",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                                ParserConstants.IDENTIFIER, "x", 1, 1, 1, 1))),
                 new TestCase("xyz",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
-                new TestCase("xyz123",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier, ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6)))
-        );
+                        Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                                ParserConstants.IDENTIFIER, "xyz", 1, 1, 1, 3))),
+                new TestCase("xyz123", Arrays.asList(new CategorizedToken(TokenCategory.Identifier,
+                        ParserConstants.IDENTIFIER, "xyz123", 1, 1, 1, 6))));
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();
@@ -213,21 +178,25 @@ public class CompilerTest {
         }
     }
 
-
     @Test
     public void categorizesLiterals() {
         List<TestCase> testCases = Arrays.asList(
                 new TestCase("123",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Literal, ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
+                                ParserConstants.UNSIGNED, "123", 1, 1, 1, 3))),
                 new TestCase("-123",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Literal, ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.IntegerConstant,
+                                ParserConstants.SIGNED, "-123", 1, 1, 1, 4))),
                 new TestCase("3.14",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Literal, ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
+                                ParserConstants.REAL_UNSIGNED, "3.14", 1, 1, 1, 4))),
                 new TestCase("-3.14",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Literal, ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.RealConstant,
+                                ParserConstants.REAL_SIGNED, "-3.14", 1, 1, 1, 5))),
                 new TestCase("\"hello world\"",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Literal, ParserConstants.STRING, "\"hello world\"", 1, 1, 1, 13)))
-        );
+                        Arrays.asList(new CategorizedToken(TokenCategory.LiteralConstant,
+                                ParserConstants.STRING, "\"hello world\"", 1, 1, 1,
+                                13))));
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();
@@ -248,19 +217,71 @@ public class CompilerTest {
     public void categorizesSpecialSymbols() {
         List<TestCase> testCases = Arrays.asList(
                 new TestCase("{",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.LBRACE, "{", 1, 1, 1, 1))),
                 new TestCase("}",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.RBRACE, "}", 1, 1, 1, 1))),
                 new TestCase("(",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.PARENTHESESL, "(", 1, 1, 1, 1))),
                 new TestCase(")",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.PARANTHESESR, ")", 1, 1, 1, 1))),
                 new TestCase(".",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.DOT, ".", 1, 1, 1, 1))),
-                new TestCase(",",
-                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol, ParserConstants.COMMA, ",", 1, 1, 1, 1)))
-        );
-
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.DOT, ".", 1, 1, 1, 1))),
+                new TestCase(",", Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                        ParserConstants.COMMA, ",", 1, 1, 1, 1))),
+                new TestCase("+",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.PLUS, "+", 1, 1, 1, 1))),
+                new TestCase("-",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.MINUS, "-", 1, 1, 1, 1))),
+                new TestCase("**",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.POWER, "**", 1, 1, 1, 2))),
+                new TestCase("*",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.MULTIPLICATION, "*", 1, 1, 1, 1))),
+                new TestCase("/",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.DIVISION, "/", 1, 1, 1, 1))),
+                new TestCase("%",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.INTEGER_DIVISION, "%", 1, 1, 1, 1))),
+                new TestCase("%%",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.REST, "%%", 1, 1, 1, 2))),
+                new TestCase("==",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.EQUAL, "==", 1, 1, 1, 2))),
+                new TestCase("!=",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.DIFFERENT, "!=", 1, 1, 1, 2))),
+                new TestCase("<",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.SMALLER, "<", 1, 1, 1, 1))),
+                new TestCase(">",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.LARGER, ">", 1, 1, 1, 1))),
+                new TestCase("<=",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.SMALLER_EQUAL, "<=", 1, 1, 1, 2))),
+                new TestCase(">=",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.LARGER_EQUAL, ">=", 1, 1, 1, 2))),
+                new TestCase("&",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.AND, "&", 1, 1, 1, 1))),
+                new TestCase("|",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.OR, "|", 1, 1, 1, 1))),
+                new TestCase("!",
+                        Arrays.asList(new CategorizedToken(TokenCategory.SpecialSymbol,
+                                ParserConstants.NOT_SYMBOL, "!", 1, 1, 1, 1)))
+          );
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();
@@ -269,7 +290,8 @@ public class CompilerTest {
 
             try {
                 var actual = compiler.tokenize();
-
+                System.out.println(actual);
+                System.out.println(testCase.expected);
                 assertEquals(testCase.expected, actual);
             } catch (Exception e) {
                 System.out.println(e);
@@ -280,11 +302,9 @@ public class CompilerTest {
 
     @Test
     public void categorizesUnknownTokens() {
-        List<TestCase> testCases = Arrays.asList(
-                new TestCase("?",
-                        Arrays.asList(new CategorizedToken(TokenCategory.Unknown, ParserConstants.UNKNOWN, "?", 1, 1, 1, 1)))
-        );
-
+        List<TestCase> testCases = Arrays
+                .asList(new TestCase("?", Arrays.asList(new CategorizedToken(TokenCategory.Unknown,
+                        ParserConstants.UNKNOWN, "?", 1, 1, 1, 1))));
 
         for (TestCase testCase : testCases) {
             var compiler = new Compiler();


### PR DESCRIPTION
Adiciona as categorias de tokens que faltavam: constante real, constante inteira.
Remove categoria de operadores e marca operadores como símbolos especiais.