### PR TITLE
fix(CategorizedToken.toString): format as specified by the professor

### DIFF
--- a/src/br/univali/ttoproject/compiler/parser/CategorizedToken.java
+++ b/src/br/univali/ttoproject/compiler/parser/CategorizedToken.java
@@ -37,16 +37,7 @@ public class CategorizedToken extends Token {
 
     @Override
     public String toString() {
-        return "CategorizedToken\n" +
-                "{\n" +
-                "   category = " + category + "\n" +
-                "   kind = " + ParserConstants.tokenImage[kind] + " - " + kind + "\n" +
-                "   image = " + image + "\n" +
-                "   beginLine = " + beginLine + "\n" +
-                "   endLine = " + endLine + "\n" +
-                "   beginColumn = " + beginColumn + "\n" +
-                "   endColumn = " + endColumn + "\n" +
-                "}\n\n";
+        return "Token " + image + " da categoria " + category + " na linha " + beginLine + ", coluna " + beginColumn;
     }
 
     public boolean isUnknownKind() {


### PR DESCRIPTION
- `CategorizedToken.toString()` retorna uma string no formato especificado pelo professor
![image](https://user-images.githubusercontent.com/17282221/115432272-91725b80-a1dc-11eb-8b79-a9a74556f252.png)
